### PR TITLE
Fix action name's spelling

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: Intaract with Google Drive
+name: Interact with Google Drive
 description: Upload/Download files to/from Google Drive
 
 branding:


### PR DESCRIPTION
I found this repo [here](https://github.com/actionsflow/actionsflow/blob/main/docs/actions.md), which links to [this page](https://github.com/marketplace/actions/intaract-with-google-drive) and noticed that "Interact" is misspelled in the Github action name. Was this intentional?